### PR TITLE
Remove bitrotted inline prototype for a libc function

### DIFF
--- a/bstrlib.c
+++ b/bstrlib.c
@@ -2913,12 +2913,6 @@ struct genBstrList g;
 #define START_VSNBUFF (256)
 #else
 
-#if defined(__GNUC__) && !defined(__APPLE__)
-/* Something is making gcc complain about this prototype not being here, so
-   I've just gone ahead and put it in. */
-extern int vsnprintf (char *buf, size_t count, const char *format, va_list arg);
-#endif
-
 #define exvsnprintf(r,b,n,f,a) {r = vsnprintf (b,n,f,a);}
 #endif
 #endif


### PR DESCRIPTION
Inserting a prototype with arbitrary interface for a missing libc function will have unintended side effects, which is what happens when you build this on NetBSD for instance.

This has plagued us over the years over in the Netatalk project, where we use a bstrlib fork. See f.e. https://github.com/Netatalk/netatalk/pull/1769